### PR TITLE
Add missing header include

### DIFF
--- a/deps/CoinCore/src/CoinNodeData.h
+++ b/deps/CoinCore/src/CoinNodeData.h
@@ -32,6 +32,7 @@
 
 #include <stdutils/uchar_vector.h>
 
+#include <functional>
 #include <list>
 #include <queue>
 


### PR DESCRIPTION
I have several more fixes besides this, but they are all specific to Arch Linux weirdness. Those will go into a separate patch that ships with the packaging script.
