### PR TITLE
Added default destructors to various exception classes

### DIFF
--- a/deps/CoinCore/src/bip39.h
+++ b/deps/CoinCore/src/bip39.h
@@ -43,7 +43,8 @@ public:
     explicit InvalidWordException(const std::string& word) : std::runtime_error("Invalid word."), word_(word) { }
 
     const std::string& word() const { return word_; }
-
+    ~InvalidWordException() throw() { }
+    
 private:
     std::string word_;
 };

--- a/deps/CoinDB/src/VaultExceptions.h
+++ b/deps/CoinDB/src/VaultExceptions.h
@@ -117,6 +117,7 @@ public:
     explicit VaultWrongNetworkException(const std::string& vault_name, const std::string& network) : VaultException("Wrong network.", VAULT_WRONG_NETWORK, vault_name), network_(network) { }
 
     const std::string&  network() const { return network_; }
+    ~VaultWrongNetworkException() throw() { }
 
 private:
     std::string network_;
@@ -128,6 +129,7 @@ public:
     explicit VaultFailedToOpenDatabaseException(const std::string& vault_name, const std::string& dberror) : VaultException("Failed to open database.", VAULT_FAILED_TO_OPEN_DATABASE, vault_name), dberror_(dberror) { }
 
     const std::string&  dberror() const { return dberror_; }
+    ~VaultFailedToOpenDatabaseException() throw() { }
 
 private:
     std::string dberror_;
@@ -139,6 +141,7 @@ public:
     explicit VaultMissingTxsException(const std::string& vault_name, const hashvector_t& txhashes) : VaultException("Vault is missing transactions.", VAULT_MISSING_TXS, vault_name), txhashes_(txhashes) { }
 
     const hashvector_t& txhashes() const { return txhashes_; }
+    ~VaultMissingTxsException() throw() { }
 
 private:
     hashvector_t txhashes_;
@@ -293,6 +296,7 @@ public:
     uint64_t available() const { return available_; }
     const std::string& username() const { return username_; }
     void username(const std::string& username) { username_ = username; }
+    ~AccountInsufficientFundsException() throw() { }
 
 private:
     uint64_t requested_;
@@ -403,6 +407,7 @@ public:
     explicit TxOutputScriptNotInUserWhitelistException(const std::string& username, const bytes_t& txoutscript) : TxException("Transaction output script is not in user whitelist.", TX_OUTPUT_SCRIPT_NOT_IN_USER_WHITELIST, bytes_t()), username_(username), txoutscript_(txoutscript) { }
     const std::string& username() const { return username_; }
     const bytes_t& txoutscript() const { return txoutscript_; }
+    ~TxOutputScriptNotInUserWhitelistException() throw() { }
 
 protected:
     std::string username_;

--- a/deps/CoinQ/src/CoinQ_exceptions.h
+++ b/deps/CoinQ/src/CoinQ_exceptions.h
@@ -47,6 +47,7 @@ class NetworkSelectorNoNetworkSelectedException : public NetworkSelectorExceptio
 {
 public:
     explicit NetworkSelectorNoNetworkSelectedException() : NetworkSelectorException("No network selected.", NETWORKSELECTOR_NO_NETWORK_SELECTED) {}
+    ~NetworkSelectorNoNetworkSelectedException() throw() { }
 };
 
 class NetworkSelectorNetworkNotRecognizedException : public NetworkSelectorException


### PR DESCRIPTION
I've added some destructors to some of the newly-added exception classes to aid in mSIGNA's compilation against GCC 4.6.
