### PR TITLE
Use `sha256(data)` instead of plain `data` in secp256k1 tests

### DIFF
--- a/deps/CoinCore/tests/secp256k1/src/secp256k1_rfc6979_test.cpp
+++ b/deps/CoinCore/tests/secp256k1/src/secp256k1_rfc6979_test.cpp
@@ -36,13 +36,13 @@ int main(int argc, char* argv[])
         cout << "Using data " << data.getHex() << endl;
         cout << "Data hash: " << sha256(data).getHex() << endl;
 
-        uchar_vector k = secp256k1_rfc6979_k(key, data);
+        uchar_vector k = secp256k1_rfc6979_k(key, sha256(data));
         cout << "k = " << k.getHex() << endl;
 
         cout << "Signing..." << endl;
-        uchar_vector sig = secp256k1_sign_rfc6979(key, data);
+        uchar_vector sig = secp256k1_sign_rfc6979(key, sha256(data));
         cout << "Signature: " << sig.getHex() << endl;
-        cout << "Valid: " << (secp256k1_verify(key, data, sig) ? "TRUE" : "FALSE") << endl << endl;
+        cout << "Valid: " << (secp256k1_verify(key, sha256(data), sig) ? "TRUE" : "FALSE") << endl << endl;
     }
     catch (const exception& e)
     {

--- a/deps/CoinCore/tests/secp256k1/src/secp256k1_test.cpp
+++ b/deps/CoinCore/tests/secp256k1/src/secp256k1_test.cpp
@@ -1,4 +1,5 @@
 #include <CoinCore/secp256k1_openssl.h>
+#include <CoinCore/hash.h>
 #include <stdutils/uchar_vector.h>
 
 #include <iostream>
@@ -35,12 +36,12 @@ int main(int argc, char* argv[])
         cout << "Public key: " << pubkey.getHex() << endl;
 
         cout << endl << "Signing data..." << flush;
-        uchar_vector sig = secp256k1_sign(key, data);
+        uchar_vector sig = secp256k1_sign(key, sha256(data));
         cout << "done." << endl;
         cout << "Signature: " << sig.getHex() << endl;
 
         cout << endl << "Verifying signature (should be valid)..." << flush;
-        if (secp256k1_verify(key, data, sig, SIGNATURE_FLAGS))  { cout << "valid." << endl; }
+        if (secp256k1_verify(key, sha256(data), sig, SIGNATURE_FLAGS))  { cout << "valid." << endl; }
         else                                    { cout << "invalid. TEST FAILED" << endl; }
 
         cout << endl << "Creating public key object..." << flush;
@@ -64,7 +65,7 @@ int main(int argc, char* argv[])
         cout << "Public key: " << pubkey.getHex() << endl;
 
         cout << endl << "Verifying signature (should be valid)..." << flush;
-        if (secp256k1_verify(key2, data, sig, SIGNATURE_FLAGS))  { cout << "valid." << endl; }
+        if (secp256k1_verify(key2, sha256(data), sig, SIGNATURE_FLAGS))  { cout << "valid." << endl; }
         else                                    { cout << "invalid. TEST FAILED" << endl; }
 
         cout << endl << "Creating new key..." << flush;
@@ -78,7 +79,7 @@ int main(int argc, char* argv[])
         cout << "Public key: " << pubkey.getHex() << endl;
         
         cout << endl << "Verifying old signature with new key (should be invalid)..." << flush;
-        if (secp256k1_verify(key, data, sig, SIGNATURE_FLAGS))   { cout << "valid. TEST FAILED" << endl; }
+        if (secp256k1_verify(key, sha256(data), sig, SIGNATURE_FLAGS))   { cout << "valid. TEST FAILED" << endl; }
         else                                    { cout << "invalid." << endl; }
     }
     catch (const exception& e)


### PR DESCRIPTION
Using `secp256k1_rfc6979_test` :

```
./secp256k1_rfc6979_test_unpatched 1000000000000000000000000000000000000000000000000000000000000000 01 | tr [:lower:] [:upper:]

CREATING KEY...DONE.
USING PRIVKEY 1000000000000000000000000000000000000000000000000000000000000000
USING DATA 01
DATA HASH: 4BF5122F344554C53BDE2EBB8CD2B7E3D1600AD631C385A5D7CCE23C7785459A
K = 76879C79C13BE69710AAACCCFC31F03C4D35FBC45539AC24C22D8098D0BBEFC4
SIGNING...
SIGNATURE: 3044022028A70449C2F7D05EC19D59C7FFD4F5C0F3E11B18245CA591FC5ABAB5580FB9A9022074A5CB5DFAF8FEC0F9DE36B6B6A68DF4E6CA39621BBB7813380CEADC3BA2A783
VALID: TRUE
```

Testing in my own implementation 

```
# private key

d1=1000000000000000000000000000000000000000000000000000000000000000
ecmul(d1)

# ecmul
# X : 8EA9666139527A8C1DD94CE4F071FD23C8B350C5A4BB33748C4BA111FACCAE0
# Y : 620EFABBC8EE2782E24E7C0CFB95C5D735B783BE9CF0F8E955AF34A30E62B945

d1x=8EA9666139527A8C1DD94CE4F071FD23C8B350C5A4BB33748C4BA111FACCAE0
d1y=620EFABBC8EE2782E24E7C0CFB95C5D735B783BE9CF0F8E955AF34A30E62B945

# data hash

z1=4BF5122F344554C53BDE2EBB8CD2B7E3D1600AD631C385A5D7CCE23C7785459A

# msigna signature

msigr=28A70449C2F7D05EC19D59C7FFD4F5C0F3E11B18245CA591FC5ABAB5580FB9A9
msigs=74A5CB5DFAF8FEC0F9DE36B6B6A68DF4E6CA39621BBB7813380CEADC3BA2A783

verify(z1,d1x,d1y,msigr,msigs)

# verify
# RX : FB0C8D4628DAFA2618A96C645131E1082D053586E98893AC44C0378BE523EFDF
# RY : A389D7CB01AEF26FD23EECB1684710BC27B776E839A3D999042D21942AB88340

(rx == msigr) 

# invalid signature

# k from msigna

msigk=76879C79C13BE69710AAACCCFC31F03C4D35FBC45539AC24C22D8098D0BBEFC4

ecmul(msigk)

# ecmul
# X : 28A70449C2F7D05EC19D59C7FFD4F5C0F3E11B18245CA591FC5ABAB5580FB9A9
# Y : 4CDC0F79E0C0304144C2303EC372C8E8C56213EE44520700CC8991CA56C7FA8D

msigkx=28A70449C2F7D05EC19D59C7FFD4F5C0F3E11B18245CA591FC5ABAB5580FB9A9
msigky=4CDC0F79E0C0304144C2303EC372C8E8C56213EE44520700CC8991CA56C7FA8D

# we see (msigkx == msigr), so something is broken with signing
# let's try to sign ourselves using the values reported by msigna

sign(msigkx,msigk,z1,d1,nn)

# sign
# R : 28A70449C2F7D05EC19D59C7FFD4F5C0F3E11B18245CA591FC5ABAB5580FB9A9
# S : 1B9D22582E067347B3454A472F09B1D5185510B13388BD76FCE781A2F31BF265

# we see (msigs != s) here.
# let's try to gather info from msigna's signature

getk(msigr,msigs,z1,d1,nn)

# K : 87C559960399A021AACB1B6DC97AB657119CA38EC7EBFEF85D3B328C119B11EC

# can't be right.. maybe it's (-k)?

mod(-msigk,nn)
897863863EC41968EF55533303CE0FC26D78E1225A0EF416FDA4DDF3FF7A517D

# not that. our data was '01'.. I wonder..

getk(msigr,msigs,1,d1,nn)

# K : 897863863EC41968EF55533303CE0FC26D78E1225A0EF416FDA4DDF3FF7A517D

# this is the problem.  instead of its hash, the data itself is being used
# let's try to recreate the "invalid" signature

sign(msigr,-msigk,1,d1,nn)

# sign
# R : 28A70449C2F7D05EC19D59C7FFD4F5C0F3E11B18245CA591FC5ABAB5580FB9A9
# S : 74A5CB5DFAF8FEC0F9DE36B6B6A68DF4E6CA39621BBB7813380CEADC3BA2A783

# we see (-msigk) was used, and not the reported (msigk) 
# we see the data (0x01) is used instead of its hash (z1)
```

After patching the test binary:

```
./secp256k1_rfc6979_test_patched 1000000000000000000000000000000000000000000000000000000000000000 01 | tr [:lower:] [:upper:]                                                                                     

CREATING KEY...DONE.
USING PRIVKEY 1000000000000000000000000000000000000000000000000000000000000000
USING DATA 01
DATA HASH: 4BF5122F344554C53BDE2EBB8CD2B7E3D1600AD631C385A5D7CCE23C7785459A
K = 3153FDDD93AF7D3F71C2233F417F84ED8F6AA9A9B0F267BAEEB1DCC69F6B41A1
SIGNING...
SIGNATURE: 30450221008F04423D49106CFED61349C0763A12ABADDB288D3DE17AE6427F5DB0FC7452F102206EB82D885F320E32ED07C29A344E278F42A013037A978923E48E5F96255B6781
VALID: TRUE
```

Testing in my own implementation

```
d1=1000000000000000000000000000000000000000000000000000000000000000
d1x=8EA9666139527A8C1DD94CE4F071FD23C8B350C5A4BB33748C4BA111FACCAE0
d1y=620EFABBC8EE2782E24E7C0CFB95C5D735B783BE9CF0F8E955AF34A30E62B945
z1=4BF5122F344554C53BDE2EBB8CD2B7E3D1600AD631C385A5D7CCE23C7785459A
msigk=3153FDDD93AF7D3F71C2233F417F84ED8F6AA9A9B0F267BAEEB1DCC69F6B41A1
msigr=8F04423D49106CFED61349C0763A12ABADDB288D3DE17AE6427F5DB0FC7452F1
msigs=6EB82D885F320E32ED07C29A344E278F42A013037A978923E48E5F96255B6781

verify(z1,d1x,d1y,msigr,msigs)

# verify
# RX : 8F04423D49106CFED61349C0763A12ABADDB288D3DE17AE6427F5DB0FC7452F1
# RY : 345559D0306C342D583A253E5937AD997A32949E1A608B48D62CE3B1C56D159A

gety(msigr)

# gety
# Y1 : CBAAA62FCF93CBD2A7C5DAC1A6C8526685CD6B61E59F74B729D31C4D3A92E695
# Y2 : 345559D0306C342D583A253E5937AD997A32949E1A608B48D62CE3B1C56D159A

# signature is valid

# trying to recreate the valid signature

sign(msigr,msigk,z1,d1,nn)


# sign
# R : 8F04423D49106CFED61349C0763A12ABADDB288D3DE17AE6427F5DB0FC7452F1
# S : 6EB82D885F320E32ED07C29A344E278F42A013037A978923E48E5F96255B6781

# match
```

same issues were found on `secp256k1_test`
