### PR TITLE
fileflush lock before header insert loop

### DIFF
--- a/deps/CoinQ/src/CoinQ_netsync.cpp
+++ b/deps/CoinQ/src/CoinQ_netsync.cpp
@@ -160,11 +160,11 @@ NetworkSync::NetworkSync(const CoinQ::CoinParams& coinParams, bool bCheckProofOf
             if (headersMessage.headers.size() > 0)
             {
                 notifySynchingHeaders();
+                boost::unique_lock<boost::mutex> fileFlushLock(m_fileFlushMutex);
                 for (auto& item: headersMessage.headers)
                 {
                     try
                     {
-                        boost::unique_lock<boost::mutex> fileFlushLock(m_fileFlushMutex);
                         if (m_blockTree.insertHeader(item)) { m_bHeadersSynched = false; }
                     }
                     catch (const std::exception& e)


### PR DESCRIPTION
When inserting a large number of headers into the block tree, flushing the block tree on every
header insertion is very slow and results in very high disk i/o activity. By locking before the for loop
we delay the file flush until all headers are inserted.