### PR TITLE
Added Peer Keep Alive timer

### DIFF
--- a/deps/CoinCore/src/CoinNodeData.cpp
+++ b/deps/CoinCore/src/CoinNodeData.cpp
@@ -2031,7 +2031,7 @@ std::string FilterAddMessage::toIndentedString(uint spaces) const
 //
 PingMessage::PingMessage()
 {
-    nonce = 0; // TODO: set to random value
+    nonce = (((uint64_t) rand() <<  0) & 0x00000000FFFFFFFFull) | (((uint64_t) rand() << 32) & 0xFFFFFFFF00000000ull);
 }
 
 uchar_vector PingMessage::getSerialized() const

--- a/deps/CoinQ/src/CoinQ_netsync.cpp
+++ b/deps/CoinQ/src/CoinQ_netsync.cpp
@@ -605,7 +605,7 @@ void NetworkSync::insertMerkleBlock(const Coin::MerkleBlock& merkleBlock, const 
     }
 }
 
-void NetworkSync::start(const std::string& host, const std::string& port)
+void NetworkSync::start(const std::string& host, const std::string& port, unsigned int keepalive_timeout)
 {
     {
         if (m_bStarted) throw runtime_error("NetworkSync - already started.");
@@ -619,7 +619,7 @@ void NetworkSync::start(const std::string& host, const std::string& port)
         m_bStarted = true;
 
         std::string port_ = port.empty() ? m_coinParams.default_port() : port;
-        m_peer.set(host, port_, m_coinParams.magic_bytes(), m_coinParams.protocol_version(), "Wallet v0.1", 0, false);
+        m_peer.set(host, port_, m_coinParams.magic_bytes(), m_coinParams.protocol_version(), "Wallet v0.1", 0, false, keepalive_timeout);
 
         LOGGER(trace) << "Starting peer " << host << ":" << port_ << "..." << endl;
         m_peer.start();
@@ -629,11 +629,11 @@ void NetworkSync::start(const std::string& host, const std::string& port)
     notifyStarted();
 }
 
-void NetworkSync::start(const std::string& host, int port)
+void NetworkSync::start(const std::string& host, int port, unsigned int keepalive_timeout)
 {
     std::stringstream ssport;
     ssport << port;
-    start(host, ssport.str());
+    start(host, ssport.str(), keepalive_timeout);
 }
 
 void NetworkSync::stop()

--- a/deps/CoinQ/src/CoinQ_netsync.h
+++ b/deps/CoinQ/src/CoinQ_netsync.h
@@ -72,8 +72,8 @@ public:
     void stop();
     bool isStarted() const { return m_bPeerStarted; }
 */
-    void start(const std::string& host, const std::string& port = "");
-    void start(const std::string& host, int port);
+    void start(const std::string& host, const std::string& port = "", unsigned int keepalive_timeout = 0);
+    void start(const std::string& host, int port, unsigned int keepalive_timeout = 0);
     void stop();
     bool connected() const { return m_bConnected; }
 


### PR DESCRIPTION
We observed that on Linux and OSX an async read operation takes too long (on the order of several minutes) before the completion handler is called with a boost error code to indicate a loss of connectivity with the remote endpoint as a result of network disruption (not when the remote endpoint explicitly tries to shutdown the tcp connection).

A possible solution is to use TCP keep-alive. After testing this proved to be a good working solution for OSX, but not on Linux.

Most modern protocols on top of TCP have their own keep-alive/timeout mechanism to determine if the remote endpoint is still reachable. This PR proposes to take this approach by adding a keep-alive timer to CoinQ::Peer.

The timeout mechanism works as follows: The peer is configured with a timeout value (in seconds). A timer is used to trigger at appropriate intervals to check if any bytes have been read in the past timeout period. If no data has arrived, a ping command is sent to the peer. If any data is received within 3 seconds the peer is determined to be still alive, otherwise the connection is stopped.

Determining when the last data arrived on the socket is done using a custom completion condition functor. Thanks to @bedeho for suggesting this technique.

In addition to being able to detect lost connectivity within the timeout period, If we use a timeout value less than 50s it will ensure that at least one packet of data will be transmitted per minute. This helps with connections going through a NAT router, as it will keep the dynamic port mapping open, preventing the connection from getting dropped by the router durning periods of low traffic.
