### PR TITLE
add missing -fPIC to dep compilation

### DIFF
--- a/deps/mk/c_flags.mk
+++ b/deps/mk/c_flags.mk
@@ -1,6 +1,6 @@
 ifdef DEBUG
-    C_FLAGS += -g
+    C_FLAGS += -g -fPIC
 else
-    C_FLAGS += -O3
+    C_FLAGS += -O3 -fPIC
 endif
 


### PR DESCRIPTION
Or else on Fedora 23 I'm getting this error:
/usr/bin/ld: sysroot/lib/libCoinCore.a(bmw.o): no se puede usar la reubicación R_X86_64_32 contra `.rodata' cuando se hace un objeto compartido; recompile con -fPIC
sysroot/lib/libCoinCore.a: error adding symbols: Valor erróneo
collect2: error: ld devolvió el estado de salida 1
Makefile:427: recipe for target 'build/release/mSIGNA' failed
make: **\* [build/release/mSIGNA] Error 1
