### PR TITLE
Added Coin::RejectMessage

### DIFF
--- a/deps/CoinCore/src/CoinNodeData.h
+++ b/deps/CoinCore/src/CoinNodeData.h
@@ -966,5 +966,26 @@ public:
     std::string toIndentedString(uint spaces = 0) const;
 };
 
-} // namespace Coin
+class RejectMessage : public CoinNodeStructure
+{
+  public:
+    std::string message;
+    char code;
+    std::string reason;
+    uchar_vector extraData;
 
+    RejectMessage();
+    RejectMessage(const uchar_vector& bytes) { setSerialized(bytes); }
+
+    const char* getCommand() const { return "reject"; }
+    uint64_t getSize() const;
+
+    uchar_vector getSerialized() const;
+    void setSerialized(const uchar_vector& bytes);
+
+    std::string toString() const;
+    std::string toIndentedString(uint spaces = 0) const;
+
+};
+
+} // namespace Coin

--- a/deps/CoinQ/src/CoinQ_netsync.cpp
+++ b/deps/CoinQ/src/CoinQ_netsync.cpp
@@ -424,6 +424,10 @@ NetworkSync::NetworkSync(const CoinQ::CoinParams& coinParams, bool bCheckProofOf
             notifyProtocolError(e.what(), -1);
         }
     });
+
+    m_peer.subscribeReject([&](CoinQ::Peer& /*peer*/, const Coin::RejectMessage& rejectMessage) {
+        notifyReject(rejectMessage);
+    });
 }
 
 NetworkSync::~NetworkSync()

--- a/deps/CoinQ/src/CoinQ_netsync.h
+++ b/deps/CoinQ/src/CoinQ_netsync.h
@@ -46,6 +46,7 @@ namespace CoinQ
 
 typedef std::function<void(const ChainMerkleBlock&, const Coin::Transaction&, unsigned int /*txindex*/, unsigned int /*txcount*/)> merkle_tx_slot_t;
 typedef std::function<void(const ChainMerkleBlock&, const bytes_t& /*txhash*/ , unsigned int /*txindex*/, unsigned int /*txcount*/)> tx_confirmed_slot_t;
+typedef std::function<void(const Coin::RejectMessage&)> reject_slot_t;
 
 class NetworkSync
 {
@@ -128,6 +129,7 @@ public:
     void subscribeRemoveBestChain(chain_header_slot_t slot) { notifyRemoveBestChain.connect(slot); }
     void subscribeBlockTreeChanged(void_slot_t slot) { notifyBlockTreeChanged.connect(slot); }
 
+    void subscribeReject(reject_slot_t slot) { notifyReject.connect(slot); }
 private:
     CoinQ::CoinParams m_coinParams;
     bool m_bCheckProofOfWork;
@@ -212,8 +214,9 @@ private:
     CoinQSignal<const ChainHeader&> notifyAddBestChain;
     CoinQSignal<const ChainHeader&> notifyRemoveBestChain;
     CoinQSignal<void> notifyBlockTreeChanged;
+
+    CoinQSignal<const Coin::RejectMessage&> notifyReject;
 };
 
     }
 }
-

--- a/deps/CoinQ/src/CoinQ_peer_io.cpp
+++ b/deps/CoinQ/src/CoinQ_peer_io.cpp
@@ -193,6 +193,13 @@ void Peer::do_read()
                     Coin::CoinNodeMessage msg(magic_bytes_, &pongMessage);
                     do_send(msg);
                 }
+                else if (command == "reject")
+                {
+                  LOGGER(trace) << "Peer read handler - REJECT" << std::endl;
+                  Coin::RejectMessage* pRejectMessage = static_cast<Coin::RejectMessage*>(peerMessage.getPayload());
+                  LOGGER(trace) << "Peer read handler - REJECT " << pRejectMessage->toString() << std::endl;
+                  notifyReject(*this, *pRejectMessage);
+                }
                 else
                 {
                     LOGGER(error) << "Peer read handler - command not implemented: " << command << std::endl;

--- a/deps/CoinQ/src/CoinQ_peer_io.h
+++ b/deps/CoinQ/src/CoinQ_peer_io.h
@@ -52,7 +52,8 @@ typedef std::function<void(Peer&, const Coin::CoinBlock&)>          peer_block_s
 typedef std::function<void(Peer&, const Coin::MerkleBlock&)>        peer_merkle_block_slot_t;
 typedef std::function<void(Peer&, const Coin::Transaction&)>        peer_tx_slot_t;
 typedef std::function<void(Peer&, const Coin::AddrMessage&)>        peer_addr_slot_t;
-typedef std::function<void(Peer&, const Coin::Inventory&)>          peer_inv_slot_t; 
+typedef std::function<void(Peer&, const Coin::Inventory&)>          peer_inv_slot_t;
+typedef std::function<void(Peer&, const Coin::RejectMessage&)>      peer_reject_slot_t;
 
 
 class Peer
@@ -99,6 +100,7 @@ public:
     void subscribeTx(peer_tx_slot_t slot) { notifyTx.connect(slot); }
     void subscribeAddr(peer_addr_slot_t slot) { notifyAddr.connect(slot); }
     void subscribeInv(peer_inv_slot_t slot) { notifyInv.connect(slot); }
+    void subscribeReject(peer_reject_slot_t slot) { notifyReject.connect(slot); }
     void subscribeProtocolError(peer_error_slot_t slot) { notifyProtocolError.connect(slot); }
 
     void subscribeStart(peer_slot_t slot) { notifyStart.connect(slot); }
@@ -317,6 +319,7 @@ private:
     CoinQSignal<Peer&, const Coin::Transaction&>        notifyTx;
     CoinQSignal<Peer&, const Coin::AddrMessage&>        notifyAddr;
     CoinQSignal<Peer&, const Coin::Inventory&>          notifyInv;
+    CoinQSignal<Peer&, const Coin::RejectMessage&>      notifyReject;
     CoinQSignal<Peer&, const std::string&, int>         notifyProtocolError;
 
     CoinQSignal<Peer&>                                  notifyStart;


### PR DESCRIPTION
Adds support to handle [`reject`](https://bitcoin.org/en/developer-reference#reject) messages from peer

Added new `Coin::RejectMessage` type.
Added `CoinQSignal<const Coin::RejectMessage&>` signal to `CoinQ::Peer` and `CoinQ::NetworkSync`